### PR TITLE
Add note regarding React.Children.toArray

### DIFF
--- a/_posts/2017-02-01-react-children-deepdive.md
+++ b/_posts/2017-02-01-react-children-deepdive.md
@@ -287,6 +287,8 @@ The above example renders the strings, but sorted:
   </a>
 </figure>
 
+> Note: The array returned by `React.Children.toArray` doesn't contain children from type function, only `ReactElement` or strings.
+
 ### Enforcing a single child
 
 If you think back to our `<Executioner />` component above, it expects only a single child to be passed, which has to be a function.


### PR DESCRIPTION
Add a note to the section of `React.Children.toArray` regarding the removal of function children when using the helper